### PR TITLE
Switch to half open intervals

### DIFF
--- a/src/loli_vm.c
+++ b/src/loli_vm.c
@@ -2359,7 +2359,7 @@ void loli_vm_execute(loli_vm_state *vm)
                  
                 if ((step_reg->value.integer > 0)
                          
-                        ? (for_temp <= rhs_reg->value.integer)
+                        ? (for_temp < rhs_reg->value.integer)
                          
                         : (for_temp >= rhs_reg->value.integer)) {
 


### PR DESCRIPTION
An iterator like `0...5` will iterate over a closed (inclusive) interval. This is essentially useless for a programming language. This PR makes the language use half-open intervals.